### PR TITLE
Add Delete Person Level tester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+db.sqlite3
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.sqlite3
+env/
+venv/
+*.egg-info/

--- a/zkteco/zkteco/settings.py
+++ b/zkteco/zkteco/settings.py
@@ -55,7 +55,7 @@ ROOT_URLCONF = 'zkteco.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/zkteco/zkteco/templates/delete_person_level.html
+++ b/zkteco/zkteco/templates/delete_person_level.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Delete Person Level</title>
+</head>
+<body>
+    <h1>Delete Person Level</h1>
+    <form method="post">
+        {% csrf_token %}
+        <label for="pin">Pin:</label>
+        <input type="text" name="pin" id="pin" required>
+        <br>
+        <label for="level_ids">Level IDs (comma separated):</label>
+        <input type="text" name="level_ids" id="level_ids" required>
+        <br>
+        <button type="submit">Delete</button>
+    </form>
+    {% if result %}
+        <h2>Result</h2>
+        <pre>{{ result|safe }}</pre>
+    {% endif %}
+    {% if error %}
+        <h2>Error</h2>
+        <pre>{{ error }}</pre>
+    {% endif %}
+    <p><a href="{% url 'home' %}">Volver al inicio</a></p>
+</body>
+</html>

--- a/zkteco/zkteco/templates/home.html
+++ b/zkteco/zkteco/templates/home.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ZKTeco Test Zone</title>
+</head>
+<body>
+    <h1>Bienvenido a la zona de pruebas para ZKTeco</h1>
+    <p>
+        Puede probar la API <strong>Delete Person Level</strong> desde el siguiente enlace:
+    </p>
+    <a href="{% url 'delete_person_level' %}">Probar Delete Person Level</a>
+</body>
+</html>

--- a/zkteco/zkteco/urls.py
+++ b/zkteco/zkteco/urls.py
@@ -1,33 +1,10 @@
-"""
-URL configuration for zkteco project.
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/5.2/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
+"""URL configuration for zkteco project."""
 from django.contrib import admin
-from django.http import HttpResponse
 from django.urls import path
-
-
-def home(request):
-    """Return a simple welcome message for the test zone."""
-    message = (
-        "bienvenido a la zona de prueba spara zkteco "
-        "para la pruevba y uso de zkteko ese seria nuestro pagina principal"
-    )
-    return HttpResponse(message)
+from . import views
 
 urlpatterns = [
-    path("", home, name="home"),
+    path("", views.home, name="home"),
+    path("delete_person_level/", views.delete_person_level, name="delete_person_level"),
     path("admin/", admin.site.urls),
 ]

--- a/zkteco/zkteco/views.py
+++ b/zkteco/zkteco/views.py
@@ -1,0 +1,33 @@
+from django.shortcuts import render
+from .zkbio_client import ZKBioClient
+
+
+def home(request):
+    """Render the home page with links to available tests."""
+    return render(request, "home.html")
+
+
+def delete_person_level(request):
+    """Call the Delete Person Level API and display the result."""
+    result = None
+    error = None
+    if request.method == "POST":
+        pin = request.POST.get("pin")
+        level_ids = request.POST.get("level_ids")
+        if not pin or not level_ids:
+            error = "Both pin and level IDs are required"
+        else:
+            client = ZKBioClient()
+            try:
+                response = client.post(
+                    "api/accLevel/deleteLevel",
+                    params={"pin": pin, "levelIds": level_ids},
+                )
+                result = response.json()
+            except Exception as exc:
+                error = str(exc)
+    return render(
+        request,
+        "delete_person_level.html",
+        {"result": result, "error": error},
+    )


### PR DESCRIPTION
## Summary
- add templates for home page and Delete Person Level
- create view functions to call Delete Person Level API
- update URL routes
- configure templates directory
- add `.gitignore`

## Testing
- `python3 zkteco/manage.py check`
- `python3 zkteco/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6848f5b4e66c832caebc3385adb590ef