### PR TITLE
Fix Django template path

### DIFF
--- a/zkteco/zkteco/settings.py
+++ b/zkteco/zkteco/settings.py
@@ -55,7 +55,12 @@ ROOT_URLCONF = 'zkteco.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [BASE_DIR / 'templates'],
+        # Look for templates in the ``templates`` directory of the project and
+        # also inside the ``zkteco`` package where the HTML files live.
+        'DIRS': [
+            BASE_DIR / 'templates',
+            BASE_DIR / 'zkteco' / 'templates',
+        ],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
## Summary
- fix template loading by adding project package's template directory to `DIRS`

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6848f82e8768832cb3e9618860668c47