### PR TITLE
Display token on home page

### DIFF
--- a/zkteco/zkteco/templates/home.html
+++ b/zkteco/zkteco/templates/home.html
@@ -5,6 +5,11 @@
 </head>
 <body>
     <h1>Bienvenido a la zona de pruebas para ZKTeco</h1>
+    {% if token %}
+    <p>Conexión con ZKTeco establecida con éxito.<br>Token: {{ token }}</p>
+    {% elif error %}
+    <p>Error al establecer la conexión: {{ error }}</p>
+    {% endif %}
     <p>
         Puede probar la API <strong>Delete Person Level</strong> desde el siguiente enlace:
     </p>

--- a/zkteco/zkteco/views.py
+++ b/zkteco/zkteco/views.py
@@ -3,8 +3,15 @@ from .zkbio_client import ZKBioClient
 
 
 def home(request):
-    """Render the home page with links to available tests."""
-    return render(request, "home.html")
+    """Render the home page and verify connection to ZKTeco."""
+    token = None
+    error = None
+    try:
+        client = ZKBioClient()
+        token = client.get_access_token()
+    except Exception as exc:
+        error = str(exc)
+    return render(request, "home.html", {"token": token, "error": error})
 
 
 def delete_person_level(request):

--- a/zkteco/zkteco/zkbio_client.py
+++ b/zkteco/zkteco/zkbio_client.py
@@ -6,9 +6,10 @@ class ZKBioClient:
     """Simple client for ZKBio CVSecurity API."""
 
     def __init__(self):
-        self.base_url = settings.BASE_URL.rstrip('/')
-        self.client_id = settings.CLIENT_ID
-        self.client_secret = settings.CLIENT_SECRET
+        api_conf = getattr(settings, "ZKBIO_API", {})
+        self.base_url = api_conf.get("BASE_URL", "").rstrip("/")
+        self.client_id = api_conf.get("CLIENT_ID")
+        self.client_secret = api_conf.get("CLIENT_SECRET")
         self._access_token = None
 
     def get_access_token(self):


### PR DESCRIPTION
## Summary
- adjust ZKBioClient to pull config from `settings.ZKBIO_API`
- show token connection info on the home page

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_684985a7d834832cad12db2d4722b135