### PR TITLE
Implement Add Person view and link

### DIFF
--- a/zkteco/zkteco/templates/add_person.html
+++ b/zkteco/zkteco/templates/add_person.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Add Person</title>
+</head>
+<body>
+    <h1>Add Person</h1>
+    <form method="post">
+        {% csrf_token %}
+        <label for="pin">Pin:</label>
+        <input type="text" name="pin" id="pin" required><br>
+
+        <label for="deptCode">Dept Code:</label>
+        <input type="text" name="deptCode" id="deptCode" required><br>
+
+        <label for="name">Name:</label>
+        <input type="text" name="name" id="name" required><br>
+
+        <label for="lastName">Last Name:</label>
+        <input type="text" name="lastName" id="lastName"><br>
+
+        <label for="gender">Gender:</label>
+        <select name="gender" id="gender">
+            <option value="M">M</option>
+            <option value="F">F</option>
+        </select><br>
+
+        <label for="cardNo">Card No:</label>
+        <input type="text" name="cardNo" id="cardNo"><br>
+
+        <label for="personPhoto">Person Photo (base64):</label>
+        <input type="text" name="personPhoto" id="personPhoto"><br>
+
+        <label for="accLevelIds">Access Level IDs:</label>
+        <input type="text" name="accLevelIds" id="accLevelIds"><br>
+
+        <label for="accStartTime">Access Start Time:</label>
+        <input type="text" name="accStartTime" id="accStartTime"><br>
+
+        <label for="accEndTime">Access End Time:</label>
+        <input type="text" name="accEndTime" id="accEndTime"><br>
+
+        <button type="submit">Add</button>
+    </form>
+
+    {% if result %}
+        <h2>Result</h2>
+        <pre>{{ result|safe }}</pre>
+    {% endif %}
+    {% if error %}
+        <h2>Error</h2>
+        <pre>{{ error }}</pre>
+    {% endif %}
+
+    <p><a href="{% url 'home' %}">Volver al inicio</a></p>
+</body>
+</html>

--- a/zkteco/zkteco/templates/home.html
+++ b/zkteco/zkteco/templates/home.html
@@ -9,5 +9,9 @@
         Puede probar la API <strong>Delete Person Level</strong> desde el siguiente enlace:
     </p>
     <a href="{% url 'delete_person_level' %}">Probar Delete Person Level</a>
+    <p>
+        Puede probar la API <strong>Add Person</strong> desde el siguiente enlace:
+    </p>
+    <a href="{% url 'add_person' %}">Probar Add Person</a>
 </body>
 </html>

--- a/zkteco/zkteco/urls.py
+++ b/zkteco/zkteco/urls.py
@@ -5,6 +5,7 @@ from . import views
 
 urlpatterns = [
     path("", views.home, name="home"),
+    path("add_person/", views.add_person, name="add_person"),
     path("delete_person_level/", views.delete_person_level, name="delete_person_level"),
     path("admin/", admin.site.urls),
 ]

--- a/zkteco/zkteco/views.py
+++ b/zkteco/zkteco/views.py
@@ -6,6 +6,36 @@ def home(request):
     return render(request, "home.html")
 
 
+def add_person(request):
+    """Call the Add Person API and display the result."""
+    result = None
+    error = None
+    if request.method == "POST":
+        params = {
+            "pin": request.POST.get("pin", "").strip(),
+            "deptCode": request.POST.get("deptCode", "").strip(),
+            "name": request.POST.get("name", "").strip(),
+            "lastName": request.POST.get("lastName", "").strip(),
+            "gender": request.POST.get("gender", "").strip(),
+            "cardNo": request.POST.get("cardNo", "").strip(),
+            "personPhoto": request.POST.get("personPhoto", "").strip(),
+            "accLevelIds": request.POST.get("accLevelIds", "").strip(),
+            "accStartTime": request.POST.get("accStartTime", "").strip(),
+            "accEndTime": request.POST.get("accEndTime", "").strip(),
+        }
+
+        if not params["pin"] or not params["deptCode"] or not params["name"]:
+            error = "pin, deptCode and name are required"
+        else:
+            client = ZKBioClient()
+            try:
+                result = client.post("api/person/add", params=params)
+            except Exception as exc:
+                error = str(exc)
+
+    return render(request, "add_person.html", {"result": result, "error": error})
+
+
 def delete_person_level(request):
     """Call the Delete Person Level API and display the result."""
     result = None


### PR DESCRIPTION
## Summary
- add new `add_person` view for ZKBio API
- add template with form to call `/api/person/add`
- link the new view from home page
- expose view via URL configuration

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python zkteco/manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_684989f69160832c8f4596af3799c272