### PR TITLE
Add personnel list view and API helper

### DIFF
--- a/zkteco/zkteco/templates/home.html
+++ b/zkteco/zkteco/templates/home.html
@@ -36,6 +36,7 @@
         <li><a class="button" href="{% url 'delete_person_level' %}">Eliminar Niveles de Persona</a></li>
         <li><a class="button" href="{% url 'get_qr_code' %}">Obtener QR Dinámico</a></li>
         <li><a class="button" href="{% url 'get_person' %}">Consultar Persona</a></li>
+        <li><a class="button" href="{% url 'list_personnel' %}">Listar Personal</a></li>
     </ul>
 </body>
 </html>

--- a/zkteco/zkteco/templates/list_personnel.html
+++ b/zkteco/zkteco/templates/list_personnel.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Listar Personal</title>
+    <meta charset="utf-8">
+    <style>
+        label {
+            display: inline-block;
+            width: 120px;
+            font-weight: bold;
+        }
+        table {
+            border-collapse: collapse;
+            margin-top: 20px;
+        }
+        th, td {
+            border: 1px solid #ccc;
+            padding: 6px 10px;
+        }
+        th {
+            background-color: #f0f0f0;
+            text-align: left;
+        }
+    </style>
+</head>
+<body>
+    <h1>Listado de Personal</h1>
+    <form method="post">
+        {% csrf_token %}
+        <label for="pins">PINs:</label>
+        <input type="text" name="pins" id="pins" placeholder="Ej: 1,2,3"><br>
+        <label for="deptCodes">Departamentos:</label>
+        <input type="text" name="deptCodes" id="deptCodes" placeholder="Ej: 1,2"><br>
+        <label for="pageNo">Página:</label>
+        <input type="number" name="pageNo" id="pageNo" value="1" min="1"><br>
+        <label for="pageSize">Tamaño:</label>
+        <input type="number" name="pageSize" id="pageSize" value="100" min="1"><br>
+        <button type="submit">Consultar</button>
+    </form>
+
+    {% if result %}
+        {% if result.data and result.data.data %}
+            <h2>Resultados (total {{ result.data.total }})</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>PIN</th>
+                        <th>Nombre</th>
+                        <th>Apellido</th>
+                        <th>Depto</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for person in result.data.data %}
+                        <tr>
+                            <td>{{ person.pin }}</td>
+                            <td>{{ person.name }}</td>
+                            <td>{{ person.lastName }}</td>
+                            <td>{{ person.deptName }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            <p>Página {{ result.data.page }} - mostrando {{ result.data.size }} de {{ result.data.total }} registros</p>
+        {% else %}
+            <h2>Resultado</h2>
+            <pre>{{ result|safe }}</pre>
+        {% endif %}
+    {% endif %}
+
+    {% if error %}
+        <h2>Error</h2>
+        <pre>{{ error }}</pre>
+    {% endif %}
+
+    <p><a href="{% url 'home' %}">Volver al inicio</a></p>
+</body>
+</html>

--- a/zkteco/zkteco/urls.py
+++ b/zkteco/zkteco/urls.py
@@ -9,5 +9,6 @@ urlpatterns = [
     path("delete_person_level/", views.delete_person_level, name="delete_person_level"),
     path("get_qr_code/", views.get_qr_code, name="get_qr_code"),
     path("get_person/", views.get_person, name="get_person"),
+    path("list_personnel/", views.list_personnel, name="list_personnel"),
     path("admin/", admin.site.urls),
 ]

--- a/zkteco/zkteco/views.py
+++ b/zkteco/zkteco/views.py
@@ -140,3 +140,37 @@ def get_person(request):
         "result": result,
         "error": error,
     })
+
+
+def list_personnel(request):
+    """Retrieve a paginated list of personnel from the ZKBio API."""
+    result = None
+    error = None
+
+    if request.method == "POST":
+        pins = request.POST.get("pins", "")
+        dept_codes = request.POST.get("deptCodes", "")
+        try:
+            page_no = int(request.POST.get("pageNo", 1))
+        except (TypeError, ValueError):
+            page_no = 1
+        try:
+            page_size = int(request.POST.get("pageSize", 100))
+        except (TypeError, ValueError):
+            page_size = 100
+
+        client = ZKBioClient()
+        try:
+            result = client.get_person_list(
+                pins=pins,
+                dept_codes=dept_codes,
+                page_no=page_no,
+                page_size=page_size,
+            )
+        except Exception as exc:
+            error = str(exc)
+
+    return render(request, "list_personnel.html", {
+        "result": result,
+        "error": error,
+    })

--- a/zkteco/zkteco/zkbio_client.py
+++ b/zkteco/zkteco/zkbio_client.py
@@ -34,6 +34,16 @@ class ZKBioClient:
         except Exception as exc:
             raise RuntimeError(f"API GET call failed: {exc}")
 
+    def get_person_list(self, pins="", dept_codes="", page_no=1, page_size=100):
+        """Return paginated personnel list using the getPersonList endpoint."""
+        data = {
+            "pins": pins,
+            "deptCodes": dept_codes,
+            "pageNo": page_no,
+            "pageSize": page_size,
+        }
+        return self.post("api/v2/person/getPersonList", data=data)
+
 # Example usage:
 # from zkteco.zkbio_client import ZKBioClient
 # client = ZKBioClient()


### PR DESCRIPTION
## Summary
- support listing personnel from ZKBio through a new helper `get_person_list`
- add `list_personnel` view with corresponding template
- expose the view in URLconf and homepage navigation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6849b2529f24832ca57f45b6570e4b2a