### PR TITLE
Add transaction listing functionality

### DIFF
--- a/zkteco/zkteco/templates/home.html
+++ b/zkteco/zkteco/templates/home.html
@@ -37,6 +37,7 @@
         <li><a class="button" href="{% url 'get_qr_code' %}">Obtener QR Dinámico</a></li>
         <li><a class="button" href="{% url 'get_person' %}">Consultar Persona</a></li>
         <li><a class="button" href="{% url 'list_personnel' %}">Listar Personal</a></li>
+        <li><a class="button" href="{% url 'list_transactions' %}">Listar Transacciones</a></li>
     </ul>
 </body>
 </html>

--- a/zkteco/zkteco/templates/list_transactions.html
+++ b/zkteco/zkteco/templates/list_transactions.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Listar Transacciones</title>
+    <meta charset="utf-8">
+    <style>
+        label {
+            display: inline-block;
+            width: 150px;
+            font-weight: bold;
+        }
+        table {
+            border-collapse: collapse;
+            margin-top: 20px;
+        }
+        th, td {
+            border: 1px solid #ccc;
+            padding: 6px 10px;
+        }
+        th {
+            background-color: #f0f0f0;
+            text-align: left;
+        }
+    </style>
+</head>
+<body>
+    <h1>Listado de Transacciones</h1>
+    <form method="post">
+        {% csrf_token %}
+        <label for="personPin">PIN:</label>
+        <input type="text" name="personPin" id="personPin"><br>
+        <label for="startDate">Inicio:</label>
+        <input type="text" name="startDate" id="startDate" placeholder="YYYY-MM-DD HH:MM:SS"><br>
+        <label for="endDate">Fin:</label>
+        <input type="text" name="endDate" id="endDate" placeholder="YYYY-MM-DD HH:MM:SS"><br>
+        <label for="pageNo">Página:</label>
+        <input type="number" name="pageNo" id="pageNo" value="1" min="1"><br>
+        <label for="pageSize">Tamaño:</label>
+        <input type="number" name="pageSize" id="pageSize" value="1000" min="1"><br>
+        <label for="version">Versión API:</label>
+        <select name="version" id="version">
+            <option value="v2" selected>v2</option>
+            <option value="v1">v1</option>
+        </select><br>
+        <label for="gateOnly">Sólo eventos de puerta</label>
+        <input type="checkbox" name="gateOnly" id="gateOnly"><br>
+        <button type="submit">Consultar</button>
+    </form>
+
+    {% if result %}
+        {% if result.data and result.data.data %}
+            <h2>Resultados (total {{ result.data.total }})</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Hora</th>
+                        <th>PIN</th>
+                        <th>Nombre</th>
+                        <th>Evento</th>
+                        <th>Dispositivo</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for txn in result.data.data %}
+                        <tr>
+                            <td>{{ txn.eventTime }}</td>
+                            <td>{{ txn.pin }}</td>
+                            <td>{{ txn.name }}</td>
+                            <td>{{ txn.eventName }}</td>
+                            <td>{{ txn.devName }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            <p>Página {{ result.data.page }} - mostrando {{ result.data.size }} de {{ result.data.total }} registros</p>
+        {% else %}
+            <h2>Resultado</h2>
+            <pre>{{ result|safe }}</pre>
+        {% endif %}
+    {% endif %}
+
+    {% if error %}
+        <h2>Error</h2>
+        <pre>{{ error }}</pre>
+    {% endif %}
+
+    <p><a href="{% url 'home' %}">Volver al inicio</a></p>
+</body>
+</html>

--- a/zkteco/zkteco/urls.py
+++ b/zkteco/zkteco/urls.py
@@ -10,5 +10,6 @@ urlpatterns = [
     path("get_qr_code/", views.get_qr_code, name="get_qr_code"),
     path("get_person/", views.get_person, name="get_person"),
     path("list_personnel/", views.list_personnel, name="list_personnel"),
+    path("list_transactions/", views.list_transactions, name="list_transactions"),
     path("admin/", admin.site.urls),
 ]

--- a/zkteco/zkteco/views.py
+++ b/zkteco/zkteco/views.py
@@ -174,3 +174,44 @@ def list_personnel(request):
         "result": result,
         "error": error,
     })
+
+
+def list_transactions(request):
+    """Retrieve access transactions using the ZKBio API."""
+    result = None
+    error = None
+
+    if request.method == "POST":
+        person_pin = request.POST.get("personPin", "")
+        start_date = request.POST.get("startDate", "")
+        end_date = request.POST.get("endDate", "")
+        try:
+            page_no = int(request.POST.get("pageNo", 1))
+        except (TypeError, ValueError):
+            page_no = 1
+        try:
+            page_size = int(request.POST.get("pageSize", 1000))
+        except (TypeError, ValueError):
+            page_size = 1000
+
+        gate_only = request.POST.get("gateOnly") == "on"
+        v2 = request.POST.get("version", "v2") == "v2"
+
+        client = ZKBioClient()
+        try:
+            result = client.get_transactions(
+                person_pin=person_pin,
+                start_date=start_date,
+                end_date=end_date,
+                page_no=page_no,
+                page_size=page_size,
+                gate_only=gate_only,
+                v2=v2,
+            )
+        except Exception as exc:
+            error = str(exc)
+
+    return render(request, "list_transactions.html", {
+        "result": result,
+        "error": error,
+    })

--- a/zkteco/zkteco/zkbio_client.py
+++ b/zkteco/zkteco/zkbio_client.py
@@ -44,6 +44,36 @@ class ZKBioClient:
         }
         return self.post("api/v2/person/getPersonList", data=data)
 
+    def get_transactions(
+        self,
+        person_pin="",
+        start_date="",
+        end_date="",
+        page_no=1,
+        page_size=1000,
+        gate_only=False,
+        v2=True,
+    ):
+        """Return paginated access transactions.
+
+        Parameters mirror the API query parameters. If ``gate_only`` is
+        ``True`` the gate transaction endpoint is used. ``v2`` selects the
+        version of the endpoint.
+        """
+
+        base = "psgTransaction/list" if gate_only else "transaction/list"
+        path = f"api/{'v2/' if v2 else ''}{base}"
+
+        params = {
+            "personPin": person_pin,
+            "startDate": start_date,
+            "endDate": end_date,
+            "pageNo": page_no,
+            "pageSize": page_size,
+        }
+
+        return self.get(path, params=params)
+
 # Example usage:
 # from zkteco.zkbio_client import ZKBioClient
 # client = ZKBioClient()


### PR DESCRIPTION
## Summary
- add `ZKBioClient.get_transactions` helper for listing access events
- add `list_transactions` view, template and URL
- link new page from home

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6849b3914644832c9d6fe661f5796a69