### PR TITLE
Add DataTables to personnel listing

### DIFF
--- a/zkteco/zkteco/templates/list_personnel.html
+++ b/zkteco/zkteco/templates/list_personnel.html
@@ -12,6 +12,7 @@
         table {
             border-collapse: collapse;
             margin-top: 20px;
+            width: 100%;
         }
         th, td {
             border: 1px solid #ccc;
@@ -22,6 +23,9 @@
             text-align: left;
         }
     </style>
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.7/css/jquery.dataTables.min.css">
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.7/js/jquery.dataTables.min.js"></script>
 </head>
 <body>
     <h1>Listado de Personal</h1>
@@ -41,13 +45,20 @@
     {% if result %}
         {% if result.data and result.data.data %}
             <h2>Resultados (total {{ result.data.total }})</h2>
-            <table>
+            <table id="personTable">
                 <thead>
                     <tr>
                         <th>PIN</th>
                         <th>Nombre</th>
                         <th>Apellido</th>
                         <th>Depto</th>
+                        <th>Código Depto</th>
+                        <th>Género</th>
+                        <th>Tarjeta</th>
+                        <th>Teléfono</th>
+                        <th>Email</th>
+                        <th>Placa</th>
+                        <th>Deshabilitado</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -57,6 +68,13 @@
                             <td>{{ person.name }}</td>
                             <td>{{ person.lastName }}</td>
                             <td>{{ person.deptName }}</td>
+                            <td>{{ person.deptCode }}</td>
+                            <td>{{ person.gender }}</td>
+                            <td>{{ person.cardNo }}</td>
+                            <td>{{ person.mobilePhone }}</td>
+                            <td>{{ person.email }}</td>
+                            <td>{{ person.carPlate }}</td>
+                            <td>{{ person.isDisabled }}</td>
                         </tr>
                     {% endfor %}
                 </tbody>
@@ -74,5 +92,14 @@
     {% endif %}
 
     <p><a href="{% url 'home' %}">Volver al inicio</a></p>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const table = document.getElementById('personTable');
+            if (table) {
+                new DataTable(table);
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add jQuery DataTables library
- show more fields about each person
- enable DataTables table initialization on listing page

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6849b3dd9070832c8a8381d78219ea0a