### PR TITLE
Add device listing views

### DIFF
--- a/zkteco/zkteco/templates/device_detail.html
+++ b/zkteco/zkteco/templates/device_detail.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Detalle de Dispositivo</title>
+    <meta charset="utf-8">
+    <style>
+        pre {
+            background-color: #f6f8fa;
+            padding: 10px;
+            border: 1px solid #ccc;
+        }
+    </style>
+</head>
+<body>
+    <h1>Detalle de Dispositivo</h1>
+
+    {% if result %}
+        <pre>{{ result|safe }}</pre>
+    {% endif %}
+
+    {% if error %}
+        <h2>Error</h2>
+        <pre>{{ error }}</pre>
+    {% endif %}
+
+    <p><a href="{% url 'list_devices' %}">Volver al listado</a></p>
+</body>
+</html>

--- a/zkteco/zkteco/templates/home.html
+++ b/zkteco/zkteco/templates/home.html
@@ -38,6 +38,7 @@
         <li><a class="button" href="{% url 'get_person' %}">Consultar Persona</a></li>
         <li><a class="button" href="{% url 'list_personnel' %}">Listar Personal</a></li>
         <li><a class="button" href="{% url 'list_transactions' %}">Listar Transacciones</a></li>
+        <li><a class="button" href="{% url 'list_devices' %}">Listar Dispositivos</a></li>
     </ul>
 </body>
 </html>

--- a/zkteco/zkteco/templates/list_devices.html
+++ b/zkteco/zkteco/templates/list_devices.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Listar Dispositivos</title>
+    <meta charset="utf-8">
+    <style>
+        label {
+            display: inline-block;
+            width: 120px;
+            font-weight: bold;
+        }
+        table {
+            border-collapse: collapse;
+            margin-top: 20px;
+            width: 100%;
+        }
+        th, td {
+            border: 1px solid #ccc;
+            padding: 6px 10px;
+        }
+        th {
+            background-color: #f0f0f0;
+            text-align: left;
+        }
+    </style>
+</head>
+<body>
+    <h1>Listado de Dispositivos</h1>
+    <form method="post">
+        {% csrf_token %}
+        <label for="module">Módulo:</label>
+        <select name="module" id="module">
+            <option value="acc" {% if module == 'acc' %}selected{% endif %}>Acceso (acc)</option>
+            <option value="psg" {% if module == 'psg' %}selected{% endif %}>Puertas (psg)</option>
+            <option value="ele" {% if module == 'ele' %}selected{% endif %}>Elevador (ele)</option>
+            <option value="ins" {% if module == 'ins' %}selected{% endif %}>FaceKiosk (ins)</option>
+        </select><br>
+        <label for="pageNo">Página:</label>
+        <input type="number" name="pageNo" id="pageNo" value="1" min="1"><br>
+        <label for="pageSize">Tamaño:</label>
+        <input type="number" name="pageSize" id="pageSize" value="100" min="1"><br>
+        <button type="submit">Consultar</button>
+    </form>
+
+    {% if result %}
+        {% if result.data and result.data.data %}
+            <h2>Resultados (total {{ result.data.total }})</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>SN</th>
+                        <th>Nombre</th>
+                        <th>Tipo</th>
+                        <th>Estado</th>
+                        <th>Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for dev in result.data.data %}
+                        <tr>
+                            <td>{{ dev.sn }}</td>
+                            <td>{{ dev.name }}</td>
+                            <td>{{ dev.type }}</td>
+                            <td>{{ dev.state }}</td>
+                            <td><a href="{% url 'device_detail' %}?module={{ module }}&sn={{ dev.sn }}">Detalle</a></td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            <p>Página {{ result.data.page }} - mostrando {{ result.data.size }} de {{ result.data.total }} registros</p>
+        {% else %}
+            <h2>Resultado</h2>
+            <pre>{{ result|safe }}</pre>
+        {% endif %}
+    {% endif %}
+
+    {% if error %}
+        <h2>Error</h2>
+        <pre>{{ error }}</pre>
+    {% endif %}
+
+    <p><a href="{% url 'home' %}">Volver al inicio</a></p>
+</body>
+</html>

--- a/zkteco/zkteco/urls.py
+++ b/zkteco/zkteco/urls.py
@@ -11,5 +11,7 @@ urlpatterns = [
     path("get_person/", views.get_person, name="get_person"),
     path("list_personnel/", views.list_personnel, name="list_personnel"),
     path("list_transactions/", views.list_transactions, name="list_transactions"),
+    path("list_devices/", views.list_devices, name="list_devices"),
+    path("device_detail/", views.device_detail, name="device_detail"),
     path("admin/", admin.site.urls),
 ]

--- a/zkteco/zkteco/views.py
+++ b/zkteco/zkteco/views.py
@@ -215,3 +215,62 @@ def list_transactions(request):
         "result": result,
         "error": error,
     })
+
+
+def list_devices(request):
+    """List devices for a selected module using the ZKBio API."""
+
+    result = None
+    error = None
+    module = "acc"
+
+    if request.method == "POST":
+        module = request.POST.get("module", "acc") or "acc"
+        try:
+            page_no = int(request.POST.get("pageNo", 1))
+        except (TypeError, ValueError):
+            page_no = 1
+        try:
+            page_size = int(request.POST.get("pageSize", 100))
+        except (TypeError, ValueError):
+            page_size = 100
+
+        client = ZKBioClient()
+        try:
+            result = client.get_device_list(
+                module=module,
+                page_no=page_no,
+                page_size=page_size,
+            )
+        except Exception as exc:
+            error = str(exc)
+
+    return render(
+        request,
+        "list_devices.html",
+        {"result": result, "error": error, "module": module},
+    )
+
+
+def device_detail(request):
+    """Retrieve information for a specific device by module and serial number."""
+
+    result = None
+    error = None
+    module = request.GET.get("module", "acc")
+    sn = request.GET.get("sn", "")
+
+    if sn:
+        client = ZKBioClient()
+        try:
+            result = client.get_device_info(module, sn)
+        except Exception as exc:
+            error = str(exc)
+    else:
+        error = "SN no proporcionado"
+
+    return render(
+        request,
+        "device_detail.html",
+        {"result": result, "error": error, "module": module, "sn": sn},
+    )

--- a/zkteco/zkteco/zkbio_client.py
+++ b/zkteco/zkteco/zkbio_client.py
@@ -74,6 +74,39 @@ class ZKBioClient:
 
         return self.get(path, params=params)
 
+    # ------------------------------------------------------------------
+    # Device management helpers
+    # ------------------------------------------------------------------
+
+    def get_device_list(self, module="acc", page_no=1, page_size=100, v2=True):
+        """Return a paginated list of devices for the given ``module``."""
+
+        if module == "acc":
+            path = f"api/{'v2/' if v2 else ''}device/{'list' if v2 else 'accList'}"
+        elif module == "psg":
+            path = f"api/{'v2/' if v2 else ''}psgDevice/list"
+        elif module == "ele":
+            path = "api/eleDevice/eleList"
+        elif module == "ins":
+            path = "api/device/attAdDeviceList"
+        else:
+            raise ValueError(f"Unknown module: {module}")
+
+        params = {"pageNo": page_no, "pageSize": page_size}
+        return self.get(path, params=params)
+
+    def get_device_info(self, module, sn):
+        """Return device information by serial number for a module."""
+
+        if module == "acc":
+            path = "api/device/getAcc"
+        elif module == "psg":
+            path = "api/psgDevice/getBySn"
+        else:
+            raise ValueError(f"Info endpoint not defined for module: {module}")
+
+        return self.get(path, params={"sn": sn})
+
 # Example usage:
 # from zkteco.zkbio_client import ZKBioClient
 # client = ZKBioClient()


### PR DESCRIPTION
## Summary
- add device management helpers in `zkbio_client`
- implement `list_devices` and `device_detail` views
- add templates for device list and detail
- link from the home page
- expose new URLs

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6849b5623f4c832c9edd771000df7875