### PR TITLE
Implement person deletion

### DIFF
--- a/zkteco/zkteco/templates/list_personnel.html
+++ b/zkteco/zkteco/templates/list_personnel.html
@@ -60,6 +60,7 @@
                         <th>Email</th>
                         <th>Placa</th>
                         <th>Deshabilitado</th>
+                        <th>Acciones</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -76,6 +77,13 @@
                             <td>{{ person.email }}</td>
                             <td>{{ person.carPlate }}</td>
                             <td>{{ person.isDisabled }}</td>
+                            <td>
+                                <form method="post" action="{% url 'delete_person' %}" class="delete-form d-inline">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="pin" value="{{ person.pin }}">
+                                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                                </form>
+                            </td>
                         </tr>
                     {% endfor %}
                 </tbody>
@@ -94,12 +102,48 @@
 
     <p><a href="{% url 'home' %}">Volver al inicio</a></p>
 
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             const table = document.getElementById('personTable');
             if (table) {
                 new DataTable(table);
             }
+
+            document.querySelectorAll('.delete-form').forEach(form => {
+                form.addEventListener('submit', function (e) {
+                    e.preventDefault();
+                    const f = this;
+                    Swal.fire({
+                        title: '¿Eliminar usuario?',
+                        text: '¿Estás seguro que deseas eliminar este usuario?',
+                        icon: 'warning',
+                        showCancelButton: true,
+                        confirmButtonText: 'Sí, eliminar',
+                        cancelButtonText: 'Cancelar'
+                    }).then((result) => {
+                        if (result.isConfirmed) {
+                            fetch(f.action, {
+                                method: 'POST',
+                                headers: {
+                                    'X-CSRFToken': f.querySelector('[name=csrfmiddlewaretoken]').value
+                                },
+                                body: new FormData(f)
+                            })
+                            .then(resp => resp.json())
+                            .then(data => {
+                                if (data.success) {
+                                    Swal.fire('Eliminado', 'Usuario eliminado correctamente', 'success');
+                                    f.closest('tr').remove();
+                                } else {
+                                    Swal.fire('Error', data.message || 'No se pudo eliminar', 'error');
+                                }
+                            })
+                            .catch(() => Swal.fire('Error', 'No se pudo eliminar', 'error'));
+                        }
+                    });
+                });
+            });
         });
     </script>
 {% endblock %}

--- a/zkteco/zkteco/urls.py
+++ b/zkteco/zkteco/urls.py
@@ -13,5 +13,6 @@ urlpatterns = [
     path("list_transactions/", views.list_transactions, name="list_transactions"),
     path("list_devices/", views.list_devices, name="list_devices"),
     path("device_detail/", views.device_detail, name="device_detail"),
+    path("delete_person/", views.delete_person, name="delete_person"),
     path("admin/", admin.site.urls),
 ]

--- a/zkteco/zkteco/views.py
+++ b/zkteco/zkteco/views.py
@@ -1,5 +1,7 @@
 from django.shortcuts import render
 from .zkbio_client import ZKBioClient
+from django.http import JsonResponse
+from django.views.decorators.http import require_POST
 import base64
 from datetime import datetime
 import io
@@ -274,3 +276,25 @@ def device_detail(request):
         "device_detail.html",
         {"result": result, "error": error, "module": module, "sn": sn},
     )
+
+
+
+
+@require_POST
+def delete_person(request):
+    """Delete a person by PIN using the ZKBio API."""
+
+    pin = request.POST.get("pin")
+    if not pin:
+        return JsonResponse({"success": False, "message": "PIN requerido"}, status=400)
+
+    client = ZKBioClient()
+    try:
+        result = client.delete_person(pin)
+    except Exception as exc:
+        return JsonResponse({"success": False, "message": str(exc)})
+
+    if isinstance(result, dict) and result.get("code") == 0:
+        return JsonResponse({"success": True})
+    else:
+        return JsonResponse({"success": False, "message": result})

--- a/zkteco/zkteco/zkbio_client.py
+++ b/zkteco/zkteco/zkbio_client.py
@@ -107,6 +107,22 @@ class ZKBioClient:
 
         return self.get(path, params={"sn": sn})
 
+    def delete_person(self, pin):
+        """Delete a person by PIN using the POST delete endpoint."""
+
+        url = urljoin(self.base_url + '/', 'api/person/delete')
+        params = {
+            'access_token': self.access_token,
+            'pin': pin,
+        }
+
+        try:
+            response = requests.post(url, params=params, verify=False)
+            response.raise_for_status()
+            return response.json()
+        except Exception as exc:
+            raise RuntimeError(f"API DELETE person failed: {exc}")
+
 # Example usage:
 # from zkteco.zkbio_client import ZKBioClient
 # client = ZKBioClient()


### PR DESCRIPTION
## Summary
- add `delete_person` helper to API client
- add Django view for deleting personnel entries
- wire up the delete view in URLs
- enable deletion from personnel list with SweetAlert confirmation

## Testing
- `python -m pytest -q`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6849b9d878ec832c8d3a135d604c25b4