### PR TITLE
Enable server-side personnel pagination

### DIFF
--- a/zkteco/zkteco/templates/list_personnel.html
+++ b/zkteco/zkteco/templates/list_personnel.html
@@ -3,153 +3,114 @@
 {% block title %}Listar Personal - ZKTeco{% endblock %}
 
 {% block extra_head %}
-    <style>
-        label {
-            display: inline-block;
-            width: 120px;
-            font-weight: bold;
-        }
-        table {
-            border-collapse: collapse;
-            margin-top: 20px;
-            width: 100%;
-        }
-        th, td {
-            border: 1px solid #ccc;
-            padding: 6px 10px;
-        }
-        th {
-            background-color: #f0f0f0;
-            text-align: left;
-        }
-    </style>
-    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.7/css/jquery.dataTables.min.css">
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="https://cdn.datatables.net/1.13.7/js/jquery.dataTables.min.js"></script>
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.7/css/jquery.dataTables.min.css">
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.7/js/jquery.dataTables.min.js"></script>
 {% endblock %}
 
 {% block content %}
-    <h1>Listado de Personal</h1>
+<h1>Listado de Personal</h1>
+<form id="filters" class="mb-3" method="post">
+    {% csrf_token %}
+    <div class="mb-2">
+        <label for="pins" class="form-label">PINs</label>
+        <input type="text" id="pins" class="form-control" placeholder="Ej: 1,2,3">
+    </div>
+    <div class="mb-2">
+        <label for="deptCodes" class="form-label">Departamentos</label>
+        <input type="text" id="deptCodes" class="form-control" placeholder="Ej: 1,2">
+    </div>
+    <button type="submit" class="btn btn-primary">Buscar</button>
+</form>
 
-    {# Formulario de consulta #}
-    <form method="post" class="mb-4">
-        {% csrf_token %}
-        <label for="pins">PINs:</label>
-        <input type="text" name="pins" id="pins" placeholder="Ej: 1,2,3"><br>
-        <label for="deptCodes">Departamentos:</label>
-        <input type="text" name="deptCodes" id="deptCodes" placeholder="Ej: 1,2"><br>
-        <label for="pageNo">Página:</label>
-        <input type="number" name="pageNo" id="pageNo" value="1" min="1"><br>
-        <label for="pageSize">Tamaño:</label>
-        <input type="number" name="pageSize" id="pageSize" value="100" min="1"><br>
-        <button type="submit" class="btn btn-primary">Consultar</button>
-    </form>
+<table id="personTable" class="display" style="width:100%">
+    <thead>
+        <tr>
+            <th>PIN</th>
+            <th>Nombre</th>
+            <th>Apellido</th>
+            <th>Depto</th>
+            <th>Código Depto</th>
+            <th>Género</th>
+            <th>Tarjeta</th>
+            <th>Teléfono</th>
+            <th>Email</th>
+            <th>Placa</th>
+            <th>Deshabilitado</th>
+            <th>Acciones</th>
+        </tr>
+    </thead>
+</table>
 
-    {% if result and result.data and result.data.data %}
-        <h2>Resultados (total {{ result.data.total }})</h2>
-        <table id="personTable">
-            <thead>
-                <tr>
-                    <th>PIN</th>
-                    <th>Nombre</th>
-                    <th>Apellido</th>
-                    <th>Depto</th>
-                    <th>Código Depto</th>
-                    <th>Género</th>
-                    <th>Tarjeta</th>
-                    <th>Teléfono</th>
-                    <th>Email</th>
-                    <th>Placa</th>
-                    <th>Deshabilitado</th>
-                    <th>Acciones</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for person in result.data.data %}
-                    <tr data-pin="{{ person.pin }}">
-                        <td>{{ person.pin }}</td>
-                        <td>{{ person.name }}</td>
-                        <td>{{ person.lastName }}</td>
-                        <td>{{ person.deptName }}</td>
-                        <td>{{ person.deptCode }}</td>
-                        <td>{{ person.gender }}</td>
-                        <td>{{ person.cardNo }}</td>
-                        <td>{{ person.mobilePhone }}</td>
-                        <td>{{ person.email }}</td>
-                        <td>{{ person.carPlate }}</td>
-                        <td>{{ person.isDisabled }}</td>
-                        <td>
-                            <button
-                                class="btn btn-sm btn-danger btn-delete"
-                                data-pin="{{ person.pin }}"
-                            >
-                                Eliminar
-                            </button>
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-        <p class="mt-3">
-            Página {{ result.data.page }} – mostrando {{ result.data.size }} de {{ result.data.total }} registros
-        </p>
-    {% elif result %}
-        <h2>Resultado</h2>
-        <pre>{{ result|safe }}</pre>
-    {% endif %}
-
-    {% if error %}
-        <h2>Error</h2>
-        <pre>{{ error }}</pre>
-    {% endif %}
-
-    <p class="mt-4"><a href="{% url 'home' %}">Volver al inicio</a></p>
+<p class="mt-4"><a href="{% url 'home' %}">Volver al inicio</a></p>
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-    if (document.getElementById('personTable')) {
-        new DataTable('#personTable');
-    }
-
     const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+    const table = new DataTable('#personTable', {
+        serverSide: true,
+        processing: true,
+        pageLength: 10,
+        ajax: {
+            url: '{% url "list_personnel_data" %}',
+            data: function(d) {
+                d.pins = document.getElementById('pins').value;
+                d.deptCodes = document.getElementById('deptCodes').value;
+            }
+        },
+        columns: [
+            { data: 'pin' },
+            { data: 'name' },
+            { data: 'lastName' },
+            { data: 'deptName' },
+            { data: 'deptCode' },
+            { data: 'gender' },
+            { data: 'cardNo' },
+            { data: 'mobilePhone' },
+            { data: 'email' },
+            { data: 'carPlate' },
+            { data: 'isDisabled' },
+            { data: null, orderable: false, render: (data, type, row) => 
+                `<button class="btn btn-sm btn-danger btn-delete" data-pin="${row.pin}">Eliminar</button>` }
+        ]
+    });
 
-    document.querySelectorAll('.btn-delete').forEach(btn => {
-        btn.addEventListener('click', () => {
-            const pin = btn.dataset.pin;
+    document.getElementById('filters').addEventListener('submit', e => {
+        e.preventDefault();
+        table.ajax.reload();
+    });
 
-            Swal.fire({
-                title: '¿Eliminar usuario?',
-                text: `PIN ${pin}`,
-                icon: 'warning',
-                showCancelButton: true,
-                confirmButtonText: 'Sí, eliminar',
-                cancelButtonText: 'Cancelar'
-            }).then(({ isConfirmed }) => {
-                if (!isConfirmed) return;
-
-                // 1) Llamada al endpoint interno de Django (misma origin)
-                fetch("{% url 'delete_person' 0 %}".replace("/0/", `/${pin}/`), {
-                    method: 'DELETE',
-                    headers: {
-                        'X-CSRFToken': csrfToken,
-                        'Accept': 'application/json'
-                    },
-                    credentials: 'same-origin'
-                })
-                .then(r => r.json())
-                .then(data => {
-                    if (data.success) {
-                        Swal.fire('Eliminado', 'Usuario eliminado correctamente', 'success');
-                        btn.closest('tr').remove();
-                    } else {
-                        Swal.fire('Error', data.message || 'No se pudo eliminar', 'error');
-                    }
-                })
-                .catch(() => Swal.fire('Error', 'No se pudo conectar al servidor', 'error'));
-            });
+    $('#personTable').on('click', '.btn-delete', function() {
+        const pin = this.dataset.pin;
+        Swal.fire({
+            title: '¿Eliminar usuario?',
+            text: `PIN ${pin}`,
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonText: 'Sí, eliminar',
+            cancelButtonText: 'Cancelar'
+        }).then(({isConfirmed}) => {
+            if (!isConfirmed) return;
+            fetch('{% url "delete_person" 0 %}'.replace('/0/', `/${pin}/`), {
+                method: 'DELETE',
+                headers: {
+                    'X-CSRFToken': csrfToken,
+                    'Accept': 'application/json'
+                },
+                credentials: 'same-origin'
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.success) {
+                    Swal.fire('Eliminado', 'Usuario eliminado correctamente', 'success');
+                    table.ajax.reload(null, false);
+                } else {
+                    Swal.fire('Error', data.message || 'No se pudo eliminar', 'error');
+                }
+            })
+            .catch(() => Swal.fire('Error', 'No se pudo conectar al servidor', 'error'));
         });
     });
 });
 </script>
-
 {% endblock %}

--- a/zkteco/zkteco/urls.py
+++ b/zkteco/zkteco/urls.py
@@ -10,6 +10,11 @@ urlpatterns = [
     path("get_qr_code/", views.get_qr_code, name="get_qr_code"),
     path("get_person/", views.get_person, name="get_person"),
     path("list_personnel/", views.list_personnel, name="list_personnel"),
+    path(
+        "list_personnel/data/",
+        views.list_personnel_data,
+        name="list_personnel_data",
+    ),
     path("list_transactions/", views.list_transactions, name="list_transactions"),
     path("list_devices/", views.list_devices, name="list_devices"),
     path("device_detail/", views.device_detail, name="device_detail"),


### PR DESCRIPTION
## Summary
- move personnel listing to a server-side DataTable
- add endpoint returning personnel JSON
- wire new URL

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6849e00bc704832c968f0888a2533d17