### PR TITLE
Add personnel photo editing support

### DIFF
--- a/zkteco/zkteco/templates/list_personnel.html
+++ b/zkteco/zkteco/templates/list_personnel.html
@@ -26,6 +26,7 @@
 <table id="personTable" class="display" style="width:100%">
     <thead>
         <tr>
+            <th>Foto</th>
             <th>PIN</th>
             <th>Nombre</th>
             <th>Apellido</th>
@@ -59,6 +60,14 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         },
         columns: [
+            {
+                data: 'personPhoto',
+                orderable: false,
+                render: data => {
+                    const src = data ? `data:image/jpeg;base64,${data}` : 'https://via.placeholder.com/40';
+                    return `<img src="${src}" class="rounded" style="width:40px;height:40px;object-fit:cover">`;
+                }
+            },
             { data: 'pin' },
             { data: 'name' },
             { data: 'lastName' },
@@ -70,8 +79,9 @@ document.addEventListener('DOMContentLoaded', () => {
             { data: 'email' },
             { data: 'carPlate' },
             { data: 'isDisabled' },
-            { data: null, orderable: false, render: (data, type, row) => 
-                `<button class="btn btn-sm btn-danger btn-delete" data-pin="${row.pin}">Eliminar</button>` }
+            { data: null, orderable: false, render: (data, type, row) =>
+                `<button class="btn btn-sm btn-primary btn-change-photo" data-pin="${row.pin}">Cambiar foto</button>
+                 <button class="btn btn-sm btn-danger btn-delete" data-pin="${row.pin}">Eliminar</button>` }
         ]
     });
 
@@ -110,6 +120,43 @@ document.addEventListener('DOMContentLoaded', () => {
             })
             .catch(() => Swal.fire('Error', 'No se pudo conectar al servidor', 'error'));
         });
+    });
+
+    $('#personTable').on('click', '.btn-change-photo', function() {
+        const pin = this.dataset.pin;
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = 'image/*';
+        input.onchange = () => {
+            const file = input.files[0];
+            if (!file) return;
+            const reader = new FileReader();
+            reader.onload = () => {
+                const base64 = reader.result.split(',')[1];
+                fetch('{% url "update_person_photo" 0 %}'.replace('/0/', `/${pin}/`), {
+                    method: 'POST',
+                    headers: {
+                        'X-CSRFToken': csrfToken,
+                        'Accept': 'application/json',
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    },
+                    body: new URLSearchParams({personPhoto: base64}),
+                    credentials: 'same-origin'
+                })
+                .then(r => r.json())
+                .then(data => {
+                    if (data.success) {
+                        Swal.fire('Actualizado', 'Foto actualizada', 'success');
+                        table.ajax.reload(null, false);
+                    } else {
+                        Swal.fire('Error', data.message || 'No se pudo actualizar', 'error');
+                    }
+                })
+                .catch(() => Swal.fire('Error', 'No se pudo conectar al servidor', 'error'));
+            };
+            reader.readAsDataURL(file);
+        };
+        input.click();
     });
 });
 </script>

--- a/zkteco/zkteco/urls.py
+++ b/zkteco/zkteco/urls.py
@@ -24,5 +24,10 @@ urlpatterns = [
         views.delete_person,
         name="delete_person"
     ),
+    path(
+        "person/update-photo/<int:pin>/",
+        views.update_person_photo,
+        name="update_person_photo",
+    ),
     path("admin/", admin.site.urls),
 ]

--- a/zkteco/zkteco/views.py
+++ b/zkteco/zkteco/views.py
@@ -315,3 +315,28 @@ def delete_person(request, pin):
         },
         status=400
     )
+
+
+@require_http_methods(["POST"])
+def update_person_photo(request, pin):
+    """Update a person's photo using the ZKBio API."""
+    photo = request.POST.get("personPhoto", "")
+    if not photo:
+        return JsonResponse({"success": False, "message": "Foto no proporcionada"}, status=400)
+
+    client = ZKBioClient()
+    try:
+        payload = client.update_person_photo(pin, photo)
+    except Exception as exc:
+        return JsonResponse({"success": False, "message": str(exc)}, status=500)
+
+    if isinstance(payload, dict) and payload.get("code") == 0:
+        return JsonResponse({"success": True})
+
+    return JsonResponse(
+        {
+            "success": False,
+            "message": payload.get("message", "No se pudo actualizar la foto"),
+        },
+        status=400,
+    )

--- a/zkteco/zkteco/zkbio_client.py
+++ b/zkteco/zkteco/zkbio_client.py
@@ -122,4 +122,9 @@ class ZKBioClient:
 
         resp = requests.post(url, params=params, verify=False, timeout=10)
         resp.raise_for_status()         # lanzará si HTTP != 2xx
-        return resp.json() 
+        return resp.json()
+
+    def update_person_photo(self, pin: int, person_photo: str):
+        """Update a person's photo using a Base64 encoded image."""
+        data = {"pin": pin, "personPhoto": person_photo}
+        return self.post("api/person/updatePersonnelPhoto", data=data)


### PR DESCRIPTION
## Summary
- show personnel photos in DataTables
- allow updating a person's photo using Base64
- expose new API helper and route

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python zkteco/manage.py check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e6b40254832cacb4f662f002a784